### PR TITLE
Add fromList method for queues.

### DIFF
--- a/Queue.elm
+++ b/Queue.elm
@@ -6,7 +6,8 @@ module Queue (
   isEmpty,
   length,
   map,
-  toList
+  toList,
+  fromList
   ) where
 
 {-| Just a simple queue data type.
@@ -18,7 +19,7 @@ module Queue (
 @docs pop
 
 # Utilities
-@docs isEmpty, length, map, toList
+@docs isEmpty, length, map, toList, fromList
 -}
 
 import List exposing ((::))
@@ -53,4 +54,9 @@ map g (Queue f b) = Queue (List.map g f) (List.map g b)
 
 toList : Queue a -> List a
 toList (Queue f b) = f ++ List.reverse b
+
+-- | O(1). 
+--   The next pop will require that the entire list be reversed.
+fromList : List a -> Queue a
+fromList = Queue []
 

--- a/Queue.elm
+++ b/Queue.elm
@@ -55,8 +55,6 @@ map g (Queue f b) = Queue (List.map g f) (List.map g b)
 toList : Queue a -> List a
 toList (Queue f b) = f ++ List.reverse b
 
--- | O(1). 
---   The next pop will require that the entire list be reversed.
 fromList : List a -> Queue a
-fromList = Queue []
+fromList xs = Queue xs []
 

--- a/elm-package.json
+++ b/elm-package.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.1.1",
+    "version": "1.2.0",
     "summary": "Just a simple queue type.",
     "repository": "https://github.com/imeckler/queue.git",
     "license": "BSD3",


### PR DESCRIPTION
Should probably increment the version number for this, since it's an addition to the public API.

~~`fromList` adds the entire provided list to the front of the queue. This allows for the maximum number of `pop`'s before the queue has to be rebalanced.~~

`fromList` adds the entire provided list to the back of the queue (the alternative is to reverse it and add the reversed list to the front of the queue). There's no cost saving either way.
