### PR TITLE
update queue for use with Elm 0.17

### DIFF
--- a/Queue.elm
+++ b/Queue.elm
@@ -1,4 +1,4 @@
-module Queue (
+module Queue exposing (
   Queue,
   empty,
   push,
@@ -7,7 +7,7 @@ module Queue (
   length,
   map,
   toList
-  ) where
+  )
 
 {-| Just a simple queue data type.
 
@@ -25,8 +25,7 @@ module Queue (
 -}
 
 import List exposing ((::))
-import Queue.Internal as I
-import Queue.Internal exposing (Queue(Queue))
+import Queue.Internal as I exposing (Queue(Queue))
 
 {-| A queue is a sequence supporting O(1) appending (`push`) of a new
     element to the back and amortizsed O(1) removal of the element at the

--- a/Queue/Internal.elm
+++ b/Queue/Internal.elm
@@ -1,4 +1,4 @@
-module Queue.Internal (Queue(..)) where
+module Queue.Internal exposing (Queue(..))
 
 {-| Internal representation of the queue type.
 

--- a/elm-package.json
+++ b/elm-package.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.1.2",
+    "version": "1.1.3",
     "summary": "Just a simple queue type.",
     "repository": "https://github.com/imeckler/queue.git",
     "license": "BSD3",
@@ -11,7 +11,7 @@
         "Queue.Internal"
     ],
     "dependencies": {
-        "elm-lang/core": "3.0.0 <= v < 4.0.0"
+        "elm-lang/core": "4.0.1 <= v < 5.0.0"
     },
-    "elm-version": "0.16.0 <= v < 0.17.0"
+    "elm-version": "0.17.0 <= v < 0.18.0"
 }


### PR DESCRIPTION
# Summary of changes
- Updates the module syntax to Elm 0.17’s style
- Bumps the patch version
- Bumps dependencies
# Explanation

I came across your queue library when tracking down dependencies for another library, and I’d like to be able to use it in Elm 0.17. The changes here should be only the minimum required to convert it into working order in Elm 0.17.
